### PR TITLE
Fix message quoting for Canary and PTB users

### DIFF
--- a/dishwasher/cogs/messagescan.py
+++ b/dishwasher/cogs/messagescan.py
@@ -11,7 +11,7 @@ class Messagescan(Cog):
     def __init__(self, bot):
         self.bot = bot
         self.link_re = re.compile(
-            r"https://discord\.com/channels/[0-9]+/[0-9]+/[0-9]+", re.IGNORECASE
+            r"https://(?:canary\.|ptb\.)?discord\.com/channels/[0-9]+/[0-9]+/[0-9]+", re.IGNORECASE
         )
         self.prevmessages = {}
 


### PR DESCRIPTION
Updated the regex used to detect message links by having it account for the additional subdomain the Canary and PTB clients include (canary.discord.com and ptb.discord.com respectively) when copying a message link.