### PR TITLE
Fix wrong creation time being shown on reminders

### DIFF
--- a/dishwasher/cogs/remind.py
+++ b/dishwasher/cogs/remind.py
@@ -29,9 +29,12 @@ class Remind(Cog):
             if uid not in ctab["remind"][jobtimestamp]:
                 continue
             job_details = ctab["remind"][jobtimestamp][uid]
-            addedtime = datetime.strptime(
-                job_details["added"], "%Y-%m-%d %H:%M:%S"
-            ).strftime("%s")
+            """ strftime operates off of the system timezone, which can cause problems
+            when time strings are stored as UTC-0. This can be fixed by appending -0000
+            to force strptime to interpret it as a UTC-0 time. """
+            addedtime = int(datetime.strptime(
+                f"{job_details['added']} -0000", "%Y-%m-%d %H:%M:%S %z"
+            ).timestamp())
             embed.add_field(
                 name=f"Reminder on <t:{jobtimestamp}:F>",
                 value=f"*Added <t:{addedtime}:R>.*\n" f"{job_details['text']}",


### PR DESCRIPTION
when running `pws reminders`, it'll show that your reminders were created in the future. this is because reminder creation times are saved as a date/time string relative to UTC-0, but when they're read back from `dishtimers.py`, a call to [`strptime`](https://github.com/vrnavi/dishwasher/blob/cc50253f02e2dcb90d68f43619b8e858d34d69ae/dishwasher/cogs/remind.py#L32-L34`) is made in order to convert the strings into timestamps. however, `strptime` works off of the system time zone and will interpret any string passed to it as relative to the system's time zone, which will cause the returned timestamp to be several hours off due to the time zone discrepancy.

this can be fixed by appending `-0000` to the date/time string and `%z` to the format string, which will instruct `strptime` to treat the date/time string as UTC-0.